### PR TITLE
added a default hook name and modified hook names to remove the word filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,12 @@ ember install ember-frost-sort
 
 ## Testing with ember-hook
 The sort component is accessible using ember-hook with the top level hook name or you can access the internal components as well -
-* Add filter button hook - `$hook('<hook-name>-add-filter')`
-* Remove filter button hook - `$hook('<hook-name>-remove-filter')`
-* Sort for each filter - `$hook('<hook-name>-filter-<index>')'`
-* Sort direction for each filter - `$hook('<hook-name>-filter-<index>-direction')'`
-* Each sort filter's select element - `$hook('<hook-name>-filter-<index>-select')'`
+* Default top level hook - `$hook('sort')`
+* Add sort button hook - `$hook('<hook-name>-add')`
+* Remove sort button hook - `$hook('<hook-name>-remove')`
+* For each sort - `$hook('<hook-name>-<index>')'`
+* Sort direction for each filter - `$hook('<hook-name>-<index>-direction')'`
+* Each sort's select element - `$hook('<hook-name>-<index>-select')'`
 
 ## Examples
 ```handlebars

--- a/addon/components/frost-sort.js
+++ b/addon/components/frost-sort.js
@@ -17,7 +17,9 @@ export default Component.extend(PropTypeMixin, {
   },
 
   getDefaultProps () {
-    return {}
+    return {
+      hook: 'sort'
+    }
   },
 
   @computed

--- a/addon/templates/components/frost-sort.hbs
+++ b/addon/templates/components/frost-sort.hbs
@@ -3,7 +3,7 @@
   {{frost-sort-item sortId=object.id
     availableOptions=unselected
     allOptions=sortableProperties
-    hook=(concat hook '-filter-' index)
+    hook=(concat hook '-' index)
     sortChange=(action 'sortArrayChange')
     initVal=object.value
     initDirection=object.direction}}
@@ -12,7 +12,7 @@
 {{#if isRemoveVisible}}
   {{#frost-button
     class='remove-button'
-    hook=(concat hook '-remove-filter')
+    hook=(concat hook '-remove')
     onClick=(action "removeFilter")
     priority=''
     size='small'}}
@@ -22,7 +22,7 @@
 
 <div class="{{hideClass}}">
   {{frost-button
-  hook=(concat hook '-add-filter')
+  hook=(concat hook '-add')
   icon='round-add'
   onClick=(action "addFilter")
   size='small'

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -4,7 +4,6 @@
     <div class="example">
       <div class="demo">
         {{frost-sort
-          hook='my-sort'
           sortableProperties=tableSortList
           onChange=(action 'sortRecords')
           sortParams=sortOrder
@@ -13,7 +12,6 @@
       <div class="snippet">
         {{format-markdown "```handlebars
 {{frost-sort
-hook='my-sort'
 sortableProperties=tableSortList
 onChange=(action 'sortRecords')
 sortParams=sortOrder}}

--- a/tests/integration/components/frost-sort-test.js
+++ b/tests/integration/components/frost-sort-test.js
@@ -25,7 +25,7 @@ describeComponent(
     beforeEach(function () {
       initialize()
       props = {
-        hook: 'my-sort',
+        hook: 'my-component-sort',
         onChange: sinon.spy(),
         sortOrder: [],
         data: [
@@ -52,23 +52,37 @@ describeComponent(
     })
 
     it('has hooks for the sort and adding filters', function () {
-      expect($hook('my-sort').hasClass('frost-sort')).to.be.true
+      expect($hook('my-component-sort').hasClass('frost-sort')).to.be.true
 
-      expect($hook('my-sort-add-filter')).to.have.length(1)
+      expect($hook('my-component-sort-add')).to.have.length(1)
     })
 
     it('has hooks for add/remove filters and sort direction', function () {
       run(() => {
-        $hook('my-sort-add-filter').click()
+        $hook('my-component-sort-add').click()
       })
 
-      expect($hook('my-sort-filter-0')).to.have.length(1)
+      expect($hook('my-component-sort-0')).to.have.length(1)
 
-      expect($hook('my-sort-remove-filter')).to.have.length(1)
+      expect($hook('my-component-sort-remove')).to.have.length(1)
 
-      expect($hook('my-sort-filter-0-select')).to.have.length(1)
+      expect($hook('my-component-sort-0-select')).to.have.length(1)
 
-      expect($hook('my-sort-filter-0-direction')).to.have.length(1)
+      expect($hook('my-component-sort-0-direction')).to.have.length(1)
+    })
+
+    it('has a default hook name', function () {
+      this.render(hbs`
+        {{frost-sort
+          sortableProperties=data
+          sortParams=sortOrder
+          onChange=onChange
+        }}`
+      )
+
+      expect($hook('sort').hasClass('frost-sort')).to.be.true
+
+      expect($hook('sort-add')).to.have.length(1)
     })
   }
 )


### PR DESCRIPTION
# fix
# CHANGELOG
- **Added** a default hook name for the sort component
- **Added** a test to validate the new default hook name in the sort component
- **Updated** the hook names by removing the word filter
- **Updated** the tests to reflect the modified hook names
- **Updated** README to explain usage of the hooks for the sort component

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ciena-frost/ember-frost-sort/23)

<!-- Reviewable:end -->
