### PR TITLE
Fixed remove button bug and improved styling on short rows

### DIFF
--- a/addon/components/frost-sort.js
+++ b/addon/components/frost-sort.js
@@ -9,6 +9,7 @@ const {Component, A, isEmpty} = Ember
 export default Component.extend(PropTypeMixin, {
   layout: layout,
   classNames: ['frost-sort'],
+  nextId: 0,
 
   propTypes: {
     hook: PropTypes.string,
@@ -64,14 +65,16 @@ export default Component.extend(PropTypeMixin, {
 
   actions: {
     addFilter () {
+      const id = this.get('nextId')
       if (this.get('filterArray').length >= (this.get('sortableProperties').length) - 1) {
         this.set('hideClass', 'button-hide')
       }
       this.get('filterArray').addObject(Ember.Object.create({
-        id: this.get('filterArray').length + 1,
+        id: id,
         value: '',
         direction: ':asc'
       }))
+      this.set('nextId', id + 1)
     },
 
     removeFilter (sortItemId) {

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -18,6 +18,8 @@
     padding: 0 10px;
     font-size: $frost-font-s;
     color: $frost-color-grey-4;
+    height: 100%;
+    white-space: nowrap;
   }
   .button-hide {
     display: none;
@@ -35,6 +37,7 @@
   align-items: center;
   border-right: 1px solid $frost-color-lgrey-1;
   padding: 0 5px 0 15px;
+  flex-shrink: 0;
 
   .frost-select {
     width: 30px;
@@ -46,5 +49,10 @@
   .animate {
     transition: transform 0.2s ease;
   }
+}
 
+.frost-sort-items {
+  display:flex;
+  flex-direction:row;
+  flex-wrap: wrap;
 }

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -54,11 +54,11 @@
   .animate {
     transition: transform 0.2s ease;
   }
-}
 
-.frost-sort-container {
-  display:flex;
-  flex-direction:row;
-  flex-wrap: wrap;
-  align-items: center;
+  .frost-sort-container {
+    display:flex;
+    flex-direction:row;
+    flex-wrap: wrap;
+    align-items: center;
+  }
 }

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -1,10 +1,10 @@
 @import 'node_modules/ember-frost-core/addon/styles/frost-theme';
 @import 'node_modules/ember-frost-core/addon/styles/frost-app';
-
 .frost-sort {
   display: flex;
   flex-direction: row;
   align-items: center;
+  align-content:flex-start;
   min-height: 50px;
 
   .frost-button.small .frost-icon {
@@ -39,6 +39,11 @@
   padding: 0 5px 0 15px;
   flex-shrink: 0;
 
+  > div {
+    display: inline-flex;
+    flex-shrink: 0;
+  }
+
   .frost-select {
     width: 30px;
   }
@@ -51,8 +56,9 @@
   }
 }
 
-.frost-sort-items {
+.frost-sort-container {
   display:flex;
   flex-direction:row;
   flex-wrap: wrap;
+  align-items: center;
 }

--- a/addon/templates/components/frost-sort.hbs
+++ b/addon/templates/components/frost-sort.hbs
@@ -1,5 +1,5 @@
 <div class="title">Sort by: </div>
-<div class="frost-sort-items">
+<div class="frost-sort-container">
 {{#each filterArray as |object index|}}
   <div class="frost-sort-item">
   {{frost-sort-item sortId=object.id

--- a/addon/templates/components/frost-sort.hbs
+++ b/addon/templates/components/frost-sort.hbs
@@ -1,4 +1,5 @@
 <div class="title">Sort by: </div>
+<div class="frost-sort-items">
 {{#each filterArray as |object index|}}
   <div class="frost-sort-item">
   {{frost-sort-item sortId=object.id
@@ -18,6 +19,7 @@
   {{/frost-button}}
   </div>
 {{/each}}
+</div>
 
 <div class="{{hideClass}}">
   {{frost-button

--- a/tests/integration/components/frost-sort-test.js
+++ b/tests/integration/components/frost-sort-test.js
@@ -116,6 +116,24 @@ describeComponent(
         expect(($hook('my-component-sort-2-select').val())).to.eql('Severity')
       })
 
+      describe('When adding a fourth field back and then clicking its remove button', function () {
+        beforeEach(function () {
+          run(() => {
+            $hook('my-component-sort-add').click()
+          })
+          fillInSortItem(3, 'Version')
+          run(() => {
+            $hook('my-component-sort-remove-3').click()
+          })
+        })
+
+        it('should remove only that field', function () {
+          expect(($hook('my-component-sort-0-select').val())).to.eql('Name')
+          expect(($hook('my-component-sort-1-select').val())).to.eql('Time')
+          expect(($hook('my-component-sort-2-select').val())).to.eql('Severity')
+        })
+      })
+
       describe('When clicking remove button for last field', function () {
         beforeEach(function () {
           run(() => {


### PR DESCRIPTION
# PATCH
# CHANGELOG
- Fixed a bug that occurred when removing sort items and then adding them back
- Improved styling when single row is too short for all sort items

![sort-responsive](https://cloud.githubusercontent.com/assets/8530858/17817298/9f37930a-65f2-11e6-8610-e9e105654c44.png)
