### PR TITLE
LTS - proptypes, coverage, scss

### DIFF
--- a/addon/components/frost-sort-item.js
+++ b/addon/components/frost-sort-item.js
@@ -1,36 +1,58 @@
 import Ember from 'ember'
-import computed from 'ember-computed-decorators'
 import layout from '../templates/components/frost-sort-item'
-import _ from 'lodash/lodash'
+import PropTypesMixin, { PropTypes } from 'ember-prop-types'
 
-const {Component, isEmpty} = Ember
+const {
+  A,
+  computed,
+  Component,
+  isEmpty
+} = Ember
 
-export default Component.extend({
+export default Component.extend(PropTypesMixin, {
   layout: layout,
   classNames: ['frost-sort-item'],
 
-  @computed
-  direction () {
-    return _.isEmpty(this.get('initDirection')) ? 'asc' : this.get('initDirection').replace(':', '')
+  propTypes: {
+    selectedItem: PropTypes.string,
+    direction: PropTypes.string,
+    initVal: PropTypes.string,
+    availableOptions: PropTypes.array,
+    allOptions: PropTypes.array
   },
+  direction: computed(function () {
+    return isEmpty(this.get('initDirection'))
+    ? 'asc'
+    : this.get('initDirection').replace(':', '')
+  }),
 
-  @computed
-  selectedItem () {
-    return _.isEmpty(this.get('initVal')) ? '' : this.get('initVal')
-  },
+  selectedItem: computed(function () {
+    return isEmpty(this.get('initVal')) ? '' : this.get('initVal')
+  }),
 
-  @computed('selectedItem', 'availableOptions', 'allOptions')
-  sortItemList (selectedItem, availableOptions, allOptions) {
-    let selectList = []
-    availableOptions.forEach(function (item) {
-      selectList.push(item)
-    })
-    if (!isEmpty(selectedItem)) {
-      selectList.push(allOptions.findBy('value', selectedItem))
+  sortItemList: computed(
+    'selectedItem',
+    'availableOptions',
+    'allOptions',
+    function () {
+      let selectedItem = this.get('selectedItem')
+      let availableOptions = this.get('availableOptions')
+      let allOptions = this.get('allOptions')
+
+      let selectList = availableOptions.slice(0)
+      if (!isEmpty(selectedItem)) {
+        selectList.pushObject(allOptions.findBy('value', selectedItem))
+      }
+      return selectList.filter(e => e)
     }
-    return selectList
+  ),
+  getDefaultProps () {
+    return {
+      direction: 'asc',
+      availableOptions: A(),
+      allOptions: A()
+    }
   },
-
   actions: {
     select (attrs) {
       this.set('selectedItem', attrs[0])
@@ -45,12 +67,12 @@ export default Component.extend({
         id: sortId,
         value: this.get('selectedItem')
       }
-      if (this.get('direction') === 'desc') {
-        this.set('direction', 'asc')
-      } else {
-        this.set('direction', 'desc')
-      }
-      attrs['direction'] = ':' + this.get('direction')
+
+      let direction = this.get('direction') === 'desc'
+      ? 'asc'
+      : 'desc'
+      attrs['direction'] = `:${direction}`
+      this.set('direction', direction)
       this.get('sortChange')(attrs)
     },
     removeItem (id) {

--- a/addon/components/frost-sort-item.js
+++ b/addon/components/frost-sort-item.js
@@ -1,10 +1,10 @@
 import Ember from 'ember'
-import layout from '../templates/components/frost-sort-item'
 import PropTypesMixin, { PropTypes } from 'ember-prop-types'
+import computed from 'ember-computed-decorators'
+import layout from '../templates/components/frost-sort-item'
 
 const {
   A,
-  computed,
   Component,
   isEmpty
 } = Ember
@@ -20,32 +20,28 @@ export default Component.extend(PropTypesMixin, {
     availableOptions: PropTypes.array,
     allOptions: PropTypes.array
   },
-  direction: computed(function () {
+  @computed
+  direction () {
     return isEmpty(this.get('initDirection'))
     ? 'asc'
     : this.get('initDirection').replace(':', '')
-  }),
-
-  selectedItem: computed(function () {
+  },
+  @computed
+  selectedItem () {
     return isEmpty(this.get('initVal')) ? '' : this.get('initVal')
-  }),
+  },
+  @computed('selectedItem', 'availableOptions', 'allOptions')
+  sortItemList () {
+    let selectedItem = this.get('selectedItem')
+    let availableOptions = this.get('availableOptions')
+    let allOptions = this.get('allOptions')
 
-  sortItemList: computed(
-    'selectedItem',
-    'availableOptions',
-    'allOptions',
-    function () {
-      let selectedItem = this.get('selectedItem')
-      let availableOptions = this.get('availableOptions')
-      let allOptions = this.get('allOptions')
-
-      let selectList = availableOptions.slice(0)
-      if (!isEmpty(selectedItem)) {
-        selectList.pushObject(allOptions.findBy('value', selectedItem))
-      }
-      return selectList.filter(e => e)
+    let selectList = availableOptions.slice(0)
+    if (!isEmpty(selectedItem)) {
+      selectList.pushObject(allOptions.findBy('value', selectedItem))
     }
-  ),
+    return selectList.filter(e => e)
+  },
   getDefaultProps () {
     return {
       direction: 'asc',

--- a/addon/components/frost-sort.js
+++ b/addon/components/frost-sort.js
@@ -96,9 +96,9 @@ export default Component.extend(PropTypesMixin, {
       return this.get('properties')
     }
 
-    let selectedProperties = this.get('filterArray').mapBy('value')
-    return this.get('properties').filter((sortListItem) => {
-      return !selectedProperties.includes(sortListItem.value)
+    let props = this.get('filterArray').mapBy('value')
+    return this.get('properties').filter(item => {
+      return props.indexOf(item.value) < 0
     })
   },
 

--- a/addon/components/frost-sort.js
+++ b/addon/components/frost-sort.js
@@ -1,19 +1,16 @@
+/* globals sortOrder properties */
 import Ember from 'ember'
 import PropTypesMixin, { PropTypes } from 'ember-prop-types'
+import computed, { oneWay } from 'ember-computed-decorators'
 import layout from '../templates/components/frost-sort'
 
 const {
   A,
   Component,
-  computed,
   deprecate,
   isEmpty,
   run
 } = Ember
-
-const {
-  oneWay
-} = computed
 
 const {
   scheduleOnce
@@ -65,17 +62,20 @@ export default Component.extend(PropTypesMixin, {
       sortOrder: A()
     }
   },
-  sortOrder: oneWay('sortParams'),
 
-  properties: oneWay('sortableProperties'),
+  @oneWay('sortParams') sortOrder,
+  @oneWay('sortableProperties') properties,
 
-  hideRemoveButton: computed('filterArray.@each.value', function () {
+  @computed('filterArray.@each.value')
+  hideRemoveButton () {
     return this.get('filterArray').length > 1
-  }),
-  hideAddButton: computed('filterArray.@each.value', function () {
+  },
+  @computed('filterArray.@each.value')
+  hideAddButton () {
     return !(this.get('filterArray').length === this.get('properties').length)
-  }),
-  filterArray: computed(function () {
+  },
+  @computed
+  filterArray () {
     let sortOrder = this.get('sortOrder')
     if (isEmpty(sortOrder)) {
       return sortOrder
@@ -89,8 +89,9 @@ export default Component.extend(PropTypesMixin, {
         })
       })
     }
-  }),
-  unselected: computed('filterArray.@each.value', function () {
+  },
+  @computed('filterArray.@each.value')
+  unselected () {
     if (isEmpty(this.get('filterArray'))) {
       return this.get('properties')
     }
@@ -99,7 +100,7 @@ export default Component.extend(PropTypesMixin, {
     return this.get('properties').filter((sortListItem) => {
       return !selectedProperties.includes(sortListItem.value)
     })
-  }),
+  },
 
   actions: {
     addFilter () {

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -30,6 +30,9 @@
 }
 
 .frost-sort-item {
+  &:last-of-type {
+    border-right: initial;
+  }
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/addon/templates/components/frost-sort-item.hbs
+++ b/addon/templates/components/frost-sort-item.hbs
@@ -9,9 +9,14 @@
   size='small'
   priority='tertiary'
   onClick=(action 'rotate' sortId)}}
-  <div class="animate {{if (eq direction 'desc') 'desc'}}">
-    {{frost-icon pack='frost-sort' icon='direction'}}
-  </div>
+{{frost-icon
+  class=(concat
+    'animate'
+    ' '
+    (if (eq direction 'desc') 'desc')
+  )
+  pack='frost-sort'
+  icon='direction'}}
 {{/frost-button}}
 {{#if hideRemoveButton}}
   {{#frost-button

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ember-browserify": "^1.1.11",
     "ember-cli": "~2.6.0",
     "ember-cli-app-version": "^1.0.0",
-    "ember-cli-blanket": "0.9.1",
+    "ember-cli-blanket": "0.9.8",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
@@ -80,7 +80,7 @@
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-sass": "^5.2.0",
     "ember-computed-decorators": "^0.2.2",
-    "ember-prop-types": "2.2.3",
+    "ember-prop-types": "2.5.6",
     "liquid-fire": "^0.24.1",
     "ember-lodash": "^0.0.6"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "ember build",
     "start": "ember server",
     "test": "npm run lint && ember test",
-    "lint": "eslint *.js addon app blueprints config tests"
+    "lint": "eslint *.js addon app blueprints config tests --fix"
   },
   "repository": "git@github.com:ciena-frost/ember-frost-sort.git",
   "engines": {
@@ -56,7 +56,7 @@
     "ember-one-way-controls": "^1.0.0",
     "ember-redux": "^1.5.1",
     "ember-resolver": "^2.0.3",
-    "ember-sinon": "0.5.0",
+    "ember-sinon": "0.5.1",
     "ember-truth-helpers": "^1.2.0",
     "ember-try": "^0.2.0",
     "eslint": "^2.10.2",

--- a/tests/unit/components/frost-sort-item-test.js
+++ b/tests/unit/components/frost-sort-item-test.js
@@ -1,0 +1,73 @@
+
+import Ember from 'ember'
+import { expect } from 'chai'
+import {
+  describeComponent,
+  it
+} from 'ember-mocha'
+import {
+  beforeEach,
+  describe
+} from 'mocha'
+import sinon from 'sinon'
+const {
+  run
+} = Ember
+const {
+  next
+} = run
+
+describeComponent(
+  'frost-sort-item',
+  'FrostSortItemComponent',
+  {
+    // Specify the other units that are required for this test
+    needs: [
+      'component:frost-select',
+      'component:frost-select-li',
+      'component:frost-button',
+      'component:frost-icon',
+      'helper:hook',
+      'helper:eq'
+    ],
+    unit: true
+  },
+  function () {
+    let component
+    beforeEach(function () {
+      component = this.subject()
+    })
+    it('renders', function () {
+      this.render()
+      expect(component).to.be.ok
+      expect(this.$()).to.have.length(1)
+    })
+    describe('actions', function () {
+      let sortChange
+      beforeEach(function () {
+        sortChange = sinon.spy()
+        component.setProperties({
+          sortChange,
+          direction: 'asc'
+        })
+        this.render()
+      })
+      it('sortChange to be called on select', function (done) {
+        next(function () {
+          component.send('select', ['test'])
+          expect(sortChange.called).to.be.true
+          done()
+        })
+      })
+
+      it('sortChange fires correctly on rotate', function (done) {
+        next(function () {
+          component.send('rotate', 'sort_id')
+          expect(sortChange.called).to.be.true
+          expect(component.get('direction')).to.equal('desc')
+          done()
+        })
+      })
+    })
+  }
+)

--- a/tests/unit/components/frost-sort-test.js
+++ b/tests/unit/components/frost-sort-test.js
@@ -1,0 +1,97 @@
+
+import Ember from 'ember'
+import { expect } from 'chai'
+import {
+  describeComponent,
+  it
+} from 'ember-mocha'
+
+import {
+  beforeEach
+} from 'mocha'
+
+const {
+  A
+} = Ember
+
+describeComponent(
+  'frost-sort',
+  'FrostSortComponent',
+  {
+    needs: [
+      'component:frost-sort-item',
+      'component:frost-select',
+      'component:frost-select-li',
+      'component:frost-button',
+      'component:frost-icon',
+      'helper:eq',
+      'helper:hook'
+    ],
+    unit: true
+  },
+  function () {
+    let component
+    beforeEach(function () {
+      component = this.subject()
+    })
+    it('renders', function () {
+      this.render()
+      expect(component).to.be.ok
+      expect(this.$()).to.have.length(1)
+    })
+    it('computed filterArray sortOrder without failing', function () {
+      let v = 'name'
+      let obj = Ember.Object.create({
+        label: v,
+        value: v
+      })
+      component.setProperties({
+        sortOrder: A([
+          Ember.Object.create({
+            direction: ':asc',
+            value: v
+          })
+        ]),
+        properties: A([
+          obj
+        ])
+      })
+      this.render()
+      let result = component.get('filterArray.firstObject.value')
+      expect(result).to.equal(obj.value)
+    })
+    it('will filter out null or falsey values from filterArray', function () {
+      let obj = Ember.Object.create({
+        label: '_test',
+        value: '_test'
+      })
+      component.setProperties({
+        sortOrder: A([
+          Ember.Object.create({
+            direction: ':asc',
+            value: 'test'
+          })
+        ]),
+        properties: A([
+          obj
+        ])
+      })
+      this.render()
+      let r = component.get('filterArray.firstObject.value')
+      expect(r).to.not.equal(obj.value)
+    })
+
+    it('computes unselected to return properties when no filter', function () {
+      let properties = A([1, 2, 3])
+
+      component.setProperties({
+        sortOrder: A(),
+        properties
+      })
+
+      this.render()
+      let r = component.get('unselected')
+      expect(r).to.equal(properties)
+    })
+  }
+)


### PR DESCRIPTION
# patch
# Changelog
- Removed computed decorators to increase test coverage
  - it would inject code that couldn't be covered.
- Default PropTypes to both `item` and `sort`
- Styling of button
  - Transition rotate would happen on div, not the svg. Causing the padding along with the svg to rotate. Not too noticeable of difference, but went ahead and fixed anyways
  - `:last-of-type` on frost-sort-item so extra line won't show up.
- Fixed bug where if user edits url, more filters can be added pass the point. 
  - Prevented add from adding in this situation.
- Upped test coverage to 💯 
