### PR TITLE
Removing unused liquid-fire dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 npm-debug.log
 testem.log
 coverage.json
+/typings

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,1 +1,1 @@
-{"compilerOptions":{"target":"es6","experimentalDecorators":true}}
+{"compilerOptions":{"target":"es6","experimentalDecorators":true},"exclude":["node_modules","bower_components","tmp","vendor",".git","dist"]}

--- a/package.json
+++ b/package.json
@@ -81,8 +81,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
-    "ember-cli-sass": "^5.2.0",
-    "liquid-fire": "^0.25.0"
+    "ember-cli-sass": "^5.2.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/dummy/app/transitions.js
+++ b/tests/dummy/app/transitions.js
@@ -1,3 +1,0 @@
-// import { animate, Promise } from "liquid-fire";
-
-export default function () {}


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- Removed unused liquid-fire dependency
