### PR TITLE
use a unique named outlet for the select. 

### DIFF
--- a/addon/components/frost-sort-item.js
+++ b/addon/components/frost-sort-item.js
@@ -7,11 +7,13 @@ const {
 import PropTypesMixin, { PropTypes } from 'ember-prop-types'
 import computed from 'ember-computed-decorators'
 import layout from '../templates/components/frost-sort-item'
+import uuid from 'ember-simple-uuid'
 
 export default Component.extend(PropTypesMixin, {
   // == Properties ============================================================
   layout: layout,
   classNames: ['frost-sort-item'],
+  targetOutlet: `frost-sort-${uuid()}`,
 
   // == State Properties ======================================================
 
@@ -39,10 +41,12 @@ export default Component.extend(PropTypesMixin, {
     ? 'asc'
     : this.get('initDirection').replace(':', '')
   },
+
   @computed
   selectedItem () {
     return isEmpty(this.get('initVal')) ? '' : this.get('initVal')
   },
+
   @computed('selectedItem', 'availableOptions', 'allOptions')
   sortItemList () {
     let selectedItem = this.get('selectedItem')
@@ -56,7 +60,7 @@ export default Component.extend(PropTypesMixin, {
     return selectList.filter(e => e)
   },
 
-  // == Actions== =============================================================
+  // == Actions================================================================
 
   actions: {
     select (attrs) {

--- a/addon/templates/components/frost-sort-item.hbs
+++ b/addon/templates/components/frost-sort-item.hbs
@@ -1,5 +1,6 @@
-{{frost-select-outlet}}
+{{frost-select-outlet name=targetOutlet}}
 {{frost-select
+  renderTarget=targetOutlet
   data=sortItemList
   hook=(concat hook '-select')
   selectedValue=selectedItem

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,8 @@
     "lodash": "^4.10.0",
     "marked": "^0.3.5",
     "perfect-scrollbar": ">=0.6.7 <2.0.0",
-    "sinonjs": "1.17.1"
+    "sinonjs": "1.17.1",
+    "node-uuid": "1.4.7"
   },
   "resolutions": {
     "ember": "~2.8.0"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "ember-prop-types": "^3.0.0",
     "ember-redux": "^1.5.1",
     "ember-resolver": "^2.0.3",
+    "ember-simple-uuid": "0.1.4",
     "ember-sinon": "0.5.1",
     "ember-truth-helpers": "^1.2.0",
     "eslint": "^3.6.1",
@@ -84,7 +85,8 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
-    "ember-cli-sass": "^5.2.0"
+    "ember-cli-sass": "^5.2.0",
+    "ember-elsewhere": "~0.4.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ember-browserify": "^1.1.11",
     "ember-cli": "~2.8.0",
     "ember-cli-app-version": "^2.0.0",
-    "ember-cli-code-coverage": "~0.3.7",
+    "ember-cli-code-coverage": "0.3.5",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",

--- a/tests/unit/components/frost-sort-item-test.js
+++ b/tests/unit/components/frost-sort-item-test.js
@@ -25,6 +25,8 @@ describeComponent(
     needs: [
       'component:frost-select',
       'component:frost-select-li',
+      'component:frost-select-outlet',
+      'component:from-elsewhere',
       'component:frost-button',
       'component:frost-icon',
       'helper:hook',

--- a/tests/unit/components/frost-sort-test.js
+++ b/tests/unit/components/frost-sort-test.js
@@ -20,6 +20,8 @@ describeComponent(
       'component:frost-sort-item',
       'component:frost-select',
       'component:frost-select-li',
+      'component:frost-select-outlet',
+      'component:from-elsewhere',
       'component:frost-button',
       'component:frost-icon',
       'helper:eq',


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
**updated** frost-sort to use a named outlet for the select.
**updated** unit tests to work with ember-elsewhere