### PR TITLE
Update to new linting functionality

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,11 @@
+{
+  "plugins": {
+    "lint": {
+      "list-item-indent": false,
+      "maximum-line-length": 119
+    }
+  },
+  "settings": {
+    "commonmark": true
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ deploy:
     branch: master
     condition: "$EMBER_TRY_SCENARIO = 'default'"
     node: 'stable'
-    tags: false
+    tags: true
 after_deploy:
 - .travis/publish-gh-pages.sh
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@
 - component `sortOrder` property also has the above format
 - component `maxActiveSortRules` renamed to `sortOrderMax`
 - component `properties` renamed to `sortingProperties`
-- added a default `sort` utility `import {sort} from 'ember-frost-sort'` that handles multiple sort orders for object properties that support `compare` (JS primitives at a minimum)
+- added a default `sort` utility `import {sort} from 'ember-frost-sort'` that handles multiple sort orders for object
+properties that support `compare` (JS primitives at a minimum)
 - spread support https://github.com/ciena-blueplanet/ember-spread
 - updated hooks that use hook qualifiers
   - `{hook}-title`
@@ -50,7 +51,7 @@
 
 
 # 5.0.2
-**Fixed** issue #41. 
+**Fixed** issue #41.
 **Cleaned** up coverage, demo and deprecation notices.
 
 
@@ -66,8 +67,8 @@
 
 
 # 4.0.0
-**update** node version and other deps. 
-**Add** rootURL. 
+**update** node version and other deps.
+**Add** rootURL.
 **update** blueprint
 
 
@@ -94,11 +95,12 @@
     - it would inject code that couldn't be covered.
 - Default PropTypes to both `item` and `sort`
 - Styling of button
-    - Transition rotate would happen on div, not the svg. Causing the padding along with the svg to rotate. Not too noticeable of difference, but went ahead and fixed anyways
+    - Transition rotate would happen on div, not the svg. Causing the padding along with the svg to rotate. Not too
+    noticeable of difference, but went ahead and fixed anyways
     - `:last-of-type` on frost-sort-item so extra line won't show up.
-- Fixed bug where if user edits url, more filters can be added pass the point. 
+- Fixed bug where if user edits url, more filters can be added pass the point.
     - Prevented add from adding in this situation.
-- Upped test coverage to 💯 
+- Upped test coverage to 💯
 
 # 2.5.0
 - Deprecated `sortParams` in favor of `sortOrder` and `sortableProperties` in favor of `properties`
@@ -123,7 +125,8 @@ https://github.com/ciena-frost/ember-frost-sort/issues/17
 # 2.3.2
 
 * **Updated** `ember-hook` dependency and blueprint to latest version
-* **Removed** unneeded configuration object for `ember-hook` since it will now work correctly in the development environment.
+* **Removed** unneeded configuration object for `ember-hook` since it will now work correctly in the development
+environment.
 
 <!-- Reviewable:start -->
 ---

--- a/package.json
+++ b/package.json
@@ -9,12 +9,9 @@
   },
   "scripts": {
     "build": "ember build",
+    "lint": "lint-all-the-things",
     "start": "ember server",
-    "test": "npm run lint && COVERAGE=true ember test",
-    "eslint": "eslint *.js addon app blueprints config tests",
-    "sass-lint": "sass-lint -q -v",
-    "md-lint": "remark *.md",
-    "lint": "npm run eslint && npm run sass-lint && npm run md-lint"
+    "test": "npm run lint && COVERAGE=true ember test"
   },
   "repository": "git@github.com:ciena-frost/ember-frost-sort.git",
   "engines": {
@@ -59,15 +56,10 @@
     "ember-simple-uuid": "0.1.4",
     "ember-sinon": "0.6.0",
     "ember-spread": "^1.1.1",
-    "ember-test-utils": "^1.6.1",
+    "ember-test-utils": "^1.10.7",
     "ember-truth-helpers": "^1.3.0",
-    "eslint": "^3.14.0",
-    "eslint-config-frost-standard": "^5.3.2",
     "loader.js": "^4.1.0",
-    "markdown-code-highlighting": "0.1.0",
-    "remark-cli": "^2.1.0",
-    "remark-lint": "^5.4.0",
-    "sass-lint": "^1.10.2"
+    "markdown-code-highlighting": "0.1.0"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [X] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

Closes: https://github.com/ciena-frost/ember-frost-sort/issues/52

# CHANGELOG
* **Updated** Travis to only publish when git tags are added in preparation for non-version bump pull requests.
* **Updated** linting to use linting tools from `ember-test-utils`.