### PR TITLE
fix(flicker): Prevent rerendering when item hasnt changed

### DIFF
--- a/addon/components/frost-sort-item.js
+++ b/addon/components/frost-sort-item.js
@@ -32,7 +32,7 @@ export default Component.extend({
 
   // == Computed properties ===================================================
 
-  @computed('_sortOrderValues.@each', '_localProperty', 'sortingProperties')
+  @computed('_sortOrderValues.[]', '_localProperty', 'sortingProperties')
   _availableProperties (_sortOrderValues, _localProperty, sortingProperties) {
     const remainingProperties = sortingProperties.filter(property => {
       return _sortOrderValues.indexOf(property.value) === -1
@@ -41,7 +41,7 @@ export default Component.extend({
     return [_localProperty].concat(remainingProperties)
   },
 
-  @computed('sortOrder.@each', 'index')
+  @computed('sortOrder.[]', 'index')
   _descending (sortOrder, index) {
     return sortOrder[index].startsWith('-')
   },
@@ -51,7 +51,7 @@ export default Component.extend({
     return _descending ? '-' : ''
   },
 
-  @computed('_sortOrderValues.@each', 'index', 'sortingProperties')
+  @computed('_sortOrderValues.[]', 'index', 'sortingProperties')
   _localProperty (_sortOrderValues, index, sortingProperties) {
     return sortingProperties.find(property => {
       return property.value === _sortOrderValues[index]
@@ -63,7 +63,7 @@ export default Component.extend({
     return _localProperty.value
   },
 
-  @computed('sortOrder.@each')
+  @computed('sortOrder.[]')
   _sortOrderValues (sortOrder) {
     return sortOrder.map(entry => {
       return entry.startsWith('-') ? entry.slice(1) : entry

--- a/addon/templates/components/frost-sort.hbs
+++ b/addon/templates/components/frost-sort.hbs
@@ -4,7 +4,7 @@
   Sort by:
 </div>
 
-{{#each sortOrder key='@id' as |sortOrderEntry index|}}
+{{#each sortOrder key="@index" as |sortOrderEntry index|}}
   {{frost-sort-item
     hideRemove=_hideRemove
     hook=(concat hookPrefix '-item')

--- a/addon/templates/components/frost-sort.hbs
+++ b/addon/templates/components/frost-sort.hbs
@@ -4,7 +4,7 @@
   Sort by:
 </div>
 
-{{#each sortOrder as |sortOrderEntry index|}}
+{{#each sortOrder key='@id' as |sortOrderEntry index|}}
   {{frost-sort-item
     hideRemove=_hideRemove
     hook=(concat hookPrefix '-item')

--- a/tests/integration/components/frost-sort-test.js
+++ b/tests/integration/components/frost-sort-test.js
@@ -378,6 +378,17 @@ describe(test.label, function () {
           $hook('test-add').click()
         })
 
+        it('does not rerender an unchanged component', function (done) {
+          const oldId = $hook('test-item', {index: 0}).attr('id')
+          $hook('test-item-direction', {index: 0}).click()
+          return wait()
+            .then(() => {
+              const currentId = $hook('test-item', {index: 0}).attr('id')
+              expect(currentId).to.equal(oldId)
+              done()
+            })
+        })
+
         it('renders a new select order entry', function () {
           expect($hook('test-item-select')).to.have.length(4)
         })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
## Relevant Links
- Using `@each` vs `.[]`
    - https://guides.emberjs.com/v2.12.0/object-model/computed-properties-and-aggregate-data/
- Specifying `{{each}}` keys to prevent redundant rerendering
    - https://emberjs.com/api/classes/Ember.Templates.helpers.html#toc_specifying-keys

# CHANGELOG
- fix(flicker): Prevent rerendering when item hasnt changed 
