### PR TITLE
Don't set Ember.Component properties in getDefaultProps()

### DIFF
--- a/addon/components/frost-sort-item.js
+++ b/addon/components/frost-sort-item.js
@@ -10,6 +10,8 @@ export default Component.extend({
 
   // == Properties ============================================================
 
+  layout,
+
   propTypes: {
     hideRemove: PropTypes.bool.isRequired,
     index: PropTypes.number.isRequired,
@@ -19,15 +21,6 @@ export default Component.extend({
       label: PropTypes.string.isRequired,
       value: PropTypes.string.isRequired
     })).isRequired
-  },
-
-  getDefaultProps () {
-    return {
-      // Keywords
-      layout
-
-      // Options
-    }
   },
 
   // == Computed properties ===================================================

--- a/addon/components/frost-sort.js
+++ b/addon/components/frost-sort.js
@@ -13,6 +13,8 @@ export default Component.extend({
 
   // == Properties ============================================================
 
+  layout,
+
   propTypes: {
     sortOrder: PropTypes.arrayOf(PropTypes.string).isRequired,
     sortOrderMax: PropTypes.number,
@@ -22,15 +24,6 @@ export default Component.extend({
     })).isRequired,
 
     onChange: PropTypes.func.isRequired
-  },
-
-  getDefaultProps () {
-    return {
-      // Keywords
-      layout
-
-      // Options
-    }
   },
 
   // == Compouted properties ==================================================


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** components to stop setting the `layout` property in `getDefaultProps()` as this method is not intended for setting Ember.Component class properties directly.