### PR TITLE
Refactor to remove need for ember-simple-uuid dependency

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,0 @@
-{
-  "directory": "bower_components",
-  "analytics": false
-}

--- a/addon/components/frost-sort.js
+++ b/addon/components/frost-sort.js
@@ -1,9 +1,8 @@
 import Ember from 'ember'
-const {assert, get} = Ember
+const {assert, get, guidFor} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {Component} from 'ember-frost-core'
 import {PropTypes} from 'ember-prop-types'
-import uuid from 'ember-simple-uuid'
 
 import layout from '../templates/components/frost-sort'
 
@@ -44,7 +43,7 @@ export default Component.extend({
   @readOnly
   @computed
   _selectOutlet (sortId) {
-    return `frost-sort-${uuid()}`
+    return `frost-sort-${guidFor({})}`
   },
 
   // == Functions =============================================================

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,0 @@
-{
-  "name": "ember-frost-sort",
-  "dependencies": {
-    "node-uuid": "1.4.7"
-  }
-}

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "ember-load-initializers": "^0.6.0",
     "ember-prop-types": "^3.10.2",
     "ember-resolver": "^2.1.1",
-    "ember-simple-uuid": "0.1.4",
     "ember-sinon": "^0.7.0",
     "ember-source": "~2.12.0",
     "ember-spread": "^1.1.1",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Refactor to remove need for `ember-simple-uuid` dependency