### PR TITLE
Flex wrap sort items if overflow

### DIFF
--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -8,16 +8,24 @@ $separator: 1px solid $frost-color-grey-6;
   align-items: center;
   min-height: 50px;
 
+  &-sort-items-container {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+
   &-title {
     color: $frost-color-grey-4;
     font-size: $frost-font-s;
+    white-space: nowrap;
   }
 
   &-item {
     display: flex;
     flex-direction: row;
     align-items: center;
-    height: 25px;
+    height: 100%;
     padding: 0 5px 0 15px;
     border-right: $separator;
 

--- a/addon/templates/components/frost-sort.hbs
+++ b/addon/templates/components/frost-sort.hbs
@@ -3,30 +3,31 @@
 <div class='{{css}}-title' data-test={{hook (concat hookPrefix '-title')}}>
   Sort by:
 </div>
+<div class='{{css}}-sort-items-container'>
+  {{#each sortOrder key="@index" as |sortOrderEntry index|}}
+    {{frost-sort-item
+      hideRemove=_hideRemove
+      hook=(concat hookPrefix '-item')
+      hookQualifiers=(hash index=index)
+      index=index
+      selectOutlet=_selectOutlet
+      sortOrder=sortOrder
+      sortingProperties=sortingProperties
+      onChange=(action 'change')
+      onRemove=(action 'remove')
+    }}
+  {{/each}}
 
-{{#each sortOrder key="@index" as |sortOrderEntry index|}}
-  {{frost-sort-item
-    hideRemove=_hideRemove
-    hook=(concat hookPrefix '-item')
-    hookQualifiers=(hash index=index)
-    index=index
-    selectOutlet=_selectOutlet
-    sortOrder=sortOrder
-    sortingProperties=sortingProperties
-    onChange=(action 'change')
-    onRemove=(action 'remove')
-  }}
-{{/each}}
-
-{{#unless _hideAdd}}
-  <span class={{concat css '-separator'}} />
-  {{frost-button
-    class=(concat css '-add')
-    hook=(concat hookPrefix '-add')
-    icon='round-add'
-    priority='tertiary'
-    size='small'
-    text='Add'
-    onClick=(action 'add')
-  }}
-{{/unless}}
+  {{#unless _hideAdd}}
+    <span class={{concat css '-separator'}} />
+    {{frost-button
+      class=(concat css '-add')
+      hook=(concat hookPrefix '-add')
+      icon='round-add'
+      priority='tertiary'
+      size='small'
+      text='Add'
+      onClick=(action 'add')
+    }}
+  {{/unless}}
+</div>


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# ember-frost-list
## Issue:
![screen shot 2017-11-20 at 12 45 30 pm](https://user-images.githubusercontent.com/9057680/33033156-7d2bffe0-cdf1-11e7-8103-4897f9e1b221.png)

## Resolution:
![screen shot 2017-11-20 at 10 49 37 am](https://user-images.githubusercontent.com/9057680/33033189-8c61b7f2-cdf1-11e7-8b38-4474d702e285.png)

# ember-frost-sort
## No change
![screen shot 2017-11-21 at 3 46 15 pm](https://user-images.githubusercontent.com/9057680/33095944-58580fb4-ced3-11e7-8009-0b151eda4e76.png)

# CHANGELOG
* Fixes https://github.com/ciena-frost/ember-frost-list/issues/161: Have frost-list flex-wrap sort if it overflows

